### PR TITLE
Explicitly remove ref_map

### DIFF
--- a/newmatic.m
+++ b/newmatic.m
@@ -89,6 +89,7 @@ ref_userblock = H5P.get_userblock(ref_fcpl);
 ref_map = memmapfile(ref_file);
 out_map = memmapfile(out_file, 'Writable', true);
 out_map.Data(1:ref_userblock) = ref_map.Data(1:ref_userblock);
+clear ref_map;
 
 mat = matfile(out_file, 'Writable', true);
 


### PR DESCRIPTION
Explicitly remove ref_map in order to close ref_file and prevent conflict with ref_file_cleanup (which is throwing "Warning: File not found or permission denied" on Windows 7)